### PR TITLE
Issue/5918 ssl server disable in  test

### DIFF
--- a/src/test/resources/config/application.properties
+++ b/src/test/resources/config/application.properties
@@ -1,0 +1,1 @@
+server.ssl.enabled=false


### PR DESCRIPTION
 Results:
[INFO]
[INFO] Tests run: 53, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- jacoco-maven-plugin:0.8.4:report (post-unit-test) @ velocloud-sdwan-driver ---
[INFO] Loading execution data file C:\project\velocloud-sdwan-driver\target\test-results\coverage\jacoco\jacoco.exec
[INFO] Analyzed bundle 'velocloud-sdwan-driver' with 12 classes
[INFO]
[INFO] --- maven-jar-plugin:3.2.2:jar (default-jar) @ velocloud-sdwan-driver ---
[INFO] Building jar: C:\project\velocloud-sdwan-driver\target\velocloud-sdwan-driver-1.0.1-SNAPSHOT.jar
[INFO]
[INFO] --- spring-boot-maven-plugin:2.7.1:repackage (repackage) @ velocloud-sdwan-driver ---
[INFO] Replacing main artifact with repackaged archive
[INFO]
[INFO] --- sortpom-maven-plugin:2.8.0:sort (default) @ velocloud-sdwan-driver ---
[INFO] Sorting file C:\project\velocloud-sdwan-driver\pom.xml
[INFO] Pom file is already sorted, exiting
[INFO]
[INFO] --- maven-install-plugin:2.5.2:install (default-install) @ velocloud-sdwan-driver ---
[INFO] Installing C:\project\velocloud-sdwan-driver\target\velocloud-sdwan-driver-1.0.1-SNAPSHOT.jar to C:\Users\gsiddala\.m2\repository\com\ibm\velocloud-sdwan-driver\velocloud-sdwan-driver\1.0.1-SNAPSHOT\velocloud-sdwan-driver-1.0.1-SNAPSHOT.jar
[INFO] Installing C:\project\velocloud-sdwan-driver\pom.xml to C:\Users\gsiddala\.m2\repository\com\ibm\velocloud-sdwan-driver\velocloud-sdwan-driver\1.0.1-SNAPSHOT\velocloud-sdwan-driver-1.0.1-SNAPSHOT.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  36.609 s
[INFO] Finished at: 2022-09-29T15:08:24+05:30
[INFO] ------------------------------------------------------------------------
